### PR TITLE
Continue porting SwiftFaiss to Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Available scripts:
 - `FlatIndex.py`: create a `FlatIndex`, add vectors to it, and search for the most similar vectors.
 - `IVFFlatIndex.py`: create an `IVFFlatIndex`, train and add vectors to it, and search for the most similar vectors.
 - `PQIndex.py`: create a `PQIndex`, train and add vectors to it, and search for the most similar vectors.
+- `PreTransformIndex.py`: create a `PreTransformIndex`, train and add vectors to it, and search for the most similar vectors.
 
 ### Installation
 
@@ -119,3 +120,83 @@ $ python3 <script_name>.py <options>
 ### Note
 
 The Python implementation now uses MLX routines instead of NumPy for array and tensor operations.
+
+### Lazy Evaluation
+
+#### Why Lazy Evaluation
+
+When you perform operations in MLX, no computation actually happens. Instead a compute graph is recorded. The actual computation only happens if an eval() is performed.
+
+MLX uses lazy evaluation because it has some nice features, some of which we describe below.
+
+#### Transforming Compute Graphs
+
+Lazy evaluation lets us record a compute graph without actually doing any computations. This is useful for function transformations like grad() and vmap() and graph optimizations.
+
+Currently, MLX does not compile and rerun compute graphs. They are all generated dynamically. However, lazy evaluation makes it much easier to integrate compilation for future performance enhancements.
+
+#### Only Compute What You Use
+
+In MLX you do not need to worry as much about computing outputs that are never used. For example:
+
+```python
+def fun(x):
+    a = fun1(x)
+    b = expensive_fun(a)
+    return a, b
+
+y, _ = fun(x)
+```
+
+Here, we never actually compute the output of expensive_fun. Use this pattern with care though, as the graph of expensive_fun is still built, and that has some cost associated to it.
+
+Similarly, lazy evaluation can be beneficial for saving memory while keeping code simple. Say you have a very large model Model derived from mlx.nn.Module. You can instantiate this model with model = Model(). Typically, this will initialize all of the weights as float32, but the initialization does not actually compute anything until you perform an eval(). If you update the model with float16 weights, your maximum consumed memory will be half that required if eager computation was used instead.
+
+This pattern is simple to do in MLX thanks to lazy computation:
+
+```python
+model = Model() # no memory used yet
+model.load_weights("weights_fp16.safetensors")
+```
+
+#### When to Evaluate
+
+A common question is when to use eval(). The trade-off is between letting graphs get too large and not batching enough useful work.
+
+For example:
+
+```python
+for _ in range(100):
+     a = a + b
+     mx.eval(a)
+     b = b * 2
+     mx.eval(b)
+```
+
+This is a bad idea because there is some fixed overhead with each graph evaluation. On the other hand, there is some slight overhead which grows with the compute graph size, so extremely large graphs (while computationally correct) can be costly.
+
+Luckily, a wide range of compute graph sizes work pretty well with MLX: anything from a few tens of operations to many thousands of operations per evaluation should be okay.
+
+Most numerical computations have an iterative outer loop (e.g. the iteration in stochastic gradient descent). A natural and usually efficient place to use eval() is at each iteration of this outer loop.
+
+Here is a concrete example:
+
+```python
+for batch in dataset:
+
+    # Nothing has been evaluated yet
+    loss, grad = value_and_grad_fn(model, batch)
+
+    # Still nothing has been evaluated
+    optimizer.update(model, grad)
+
+    # Evaluate the loss and the new parameters which will
+    # run the full gradient computation and optimizer update
+    mx.eval(loss, model.parameters())
+```
+
+An important behavior to be aware of is when the graph will be implicitly evaluated. Anytime you print an array, convert it to an numpy.ndarray, or otherwise access its memory via memoryview, the graph will be evaluated. Saving arrays via save() (or any other MLX saving functions) will also evaluate the array.
+
+Calling array.item() on a scalar array will also evaluate it. In the example above, printing the loss (print(loss)) or adding the loss scalar to a list (losses.append(loss.item())) would cause a graph evaluation. If these lines are before mx.eval(loss, model.parameters()) then this will be a partial evaluation, computing only the forward pass.
+
+Also, calling eval() on an array or set of arrays multiple times is perfectly fine. This is effectively a no-op.

--- a/python/PreTransformIndex.py
+++ b/python/PreTransformIndex.py
@@ -9,12 +9,15 @@ class PreTransformIndex:
 
     def train(self, xs):
         transformed_xs = self.vector_transform.apply(xs)
+        transformed_xs = mlx.core.eval(transformed_xs)
         self.sub_index.train(transformed_xs)
 
     def add(self, vectors):
         transformed_vectors = self.vector_transform.apply(vectors)
+        transformed_vectors = mlx.core.eval(transformed_vectors)
         self.sub_index.add(transformed_vectors)
 
     def search(self, query, k):
         transformed_query = self.vector_transform.apply(query)
+        transformed_query = mlx.core.eval(transformed_query)
         return self.sub_index.search(transformed_query, k)

--- a/python/Utils.py
+++ b/python/Utils.py
@@ -6,13 +6,28 @@ def load_data(file_path):
     with open(file_path, 'r') as file:
         for line in file:
             data.append([float(x) for x in line.strip().split()])
-    return mlx.array(data, dtype=np.float32)
+    return mlx.core.eval.array(data, dtype=np.float32)
 
 def encode_sentences(sentences, embedding_model):
     embeddings = []
     for sentence in sentences:
         embeddings.append(embedding_model.encode(sentence))
-    return mlx.array(embeddings, dtype=np.float32)
+    return mlx.core.eval.array(embeddings, dtype=np.float32)
 
 def create_matrix(rows, columns):
-    return mlx.random.rand(rows, columns).astype(np.float32)
+    return mlx.core.eval.random.rand(rows, columns).astype(np.float32)
+
+def normalize_data(data):
+    data = mlx.core.eval.array(data, dtype=np.float32)
+    norms = mlx.core.eval.linalg.norm(data, axis=1, keepdims=True)
+    return data / norms
+
+def compute_distances(data, query):
+    data = mlx.core.eval.array(data, dtype=np.float32)
+    query = mlx.core.eval.array(query, dtype=np.float32)
+    return mlx.core.eval.linalg.norm(data - query, axis=1)
+
+def random_projection(data, output_dim):
+    data = mlx.core.eval.array(data, dtype=np.float32)
+    projection_matrix = mlx.core.eval.random.randn(data.shape[1], output_dim).astype(np.float32)
+    return mlx.core.eval.dot(data, projection_matrix)


### PR DESCRIPTION
Continue porting SwiftFaiss to Python by implementing the `PreTransformIndex` class and updating utility functions.

* **PreTransformIndex.py**
  - Implement the `PreTransformIndex` class in Python.
  - Add methods `__init__`, `train`, `add`, and `search`.
  - Use `mlx.core.eval` for lazy evaluation in the methods.

* **Utils.py**
  - Update functions to use `mlx.core.eval` for array and tensor operations.
  - Add new utility functions: `normalize_data`, `compute_distances`, and `random_projection`.

* **README.md**
  - Add instructions for using the new `PreTransformIndex.py` file.
  - Include a section explaining lazy evaluation in MLX and when to use `mlx.core.eval`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sydneyrenee/MetalFaiss/pull/4?shareId=85c2516d-e3d7-449c-9fb6-cfdc891f7551).